### PR TITLE
Fix an express deprecation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -96,7 +96,7 @@ function (req, res, rate, limit, resetTime) {
 function (req, res, rate, limit, resetTime, next) {
             
     // HTTP code 420 from http://mehack.com/inventing-a-http-response-code-aka-seriously
-    res.json({error: 'Rate limit exceeded. Check headers for limit information.'}, {status: 420});
+    res.status(420).json({error: 'Rate limit exceeded. Check headers for limit information.'});
 }
 ```
 
@@ -218,7 +218,7 @@ var headersMiddleware = rate.middleware(
         onLimitReached: function (req, res, rate, limit, resetTime, next) {
             
             // HTTP code 420 from http://mehack.com/inventing-a-http-response-code-aka-seriously
-            res.json({error: 'Rate limit exceeded. Check headers for limit information.'}, {status: 420});
+            res.status(420).json({error: 'Rate limit exceeded. Check headers for limit information.'});
         }
 });
 

--- a/examples/simple-redis.js
+++ b/examples/simple-redis.js
@@ -102,7 +102,7 @@ var headersMiddleware = rate.middleware(
         onLimitReached: function (req, res, rate, limit, resetTime, next) {
             
             // HTTP code 420 from http://mehack.com/inventing-a-http-response-code-aka-seriously
-            res.json({error: 'Rate limit exceeded. Check headers for limit information.'}, {status: 420});
+            res.status(420).json({error: 'Rate limit exceeded. Check headers for limit information.'});
         }
 });
 

--- a/lib/rate.js
+++ b/lib/rate.js
@@ -58,7 +58,7 @@ exports.defaults = function () {
         onLimitReached: function (req, res, rate, limit, resetTime, next) {
             
             // HTTP code 420 from http://mehack.com/inventing-a-http-response-code-aka-seriously
-            res.json({error: 'Rate limit exceeded. Check headers for limit information.'}, {status: 420});
+            res.status(420).json({error: 'Rate limit exceeded. Check headers for limit information.'});
         }
 
     };


### PR DESCRIPTION
This message was given when rate limiting is hit:

```
express deprecated res.json(status, obj): Use res.status(status).json(obj) instead node_modules/express-rate/lib/rate.js:61:17
```

The deprecation is mentioned in https://github.com/strongloop/express/releases/tag/4.7.0

Also update the docs and example.
