### PR TITLE
remove multi , make it work with twemproxy

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -33,26 +33,27 @@ RedisRateHandler.prototype._increment_key = function (key, increment, rate_optio
         rate = 1,
         self = this;
 
-    this.client.multi()
-        .incrby(key, increment)
-        .ttl(key)
-        .exec(function (err, replies) {
+    this.client
+        .incrby(key, increment, function (err, replies) {
             
-        if (err) next(err);
+          if (err) next(err);
 
-        currentTime = (new Date()).getTime();
+           currentTime = (new Date()).getTime();
         
-        rate = replies[0];
+           rate = replies;
+           self.client.ttl(key, function (err, rttl) {
+             if (err) next(err);
 
-        // if the key was just created now, we need to set an expiraton
-        if(rate === increment) {
-            ttl = currentTime + (rate_options.interval * 1000);
-            self.client.expire(key, rate_options.interval);
-        } else {
-            ttl = currentTime + (replies[1] * 1000);
-        }
-
-        if (callback) callback(rate, ttl);
+             // if the key was just created now, we need to set an expiraton
+             if(rate === increment) {
+               ttl = currentTime + (rate_options.interval * 1000);
+               self.client.expire(key, rate_options.interval);
+             } else {
+               ttl = currentTime + (replies[1] * 1000);
+             }
+    
+             if (callback) callback(rate, ttl);
+            });
     });
 };
 


### PR DESCRIPTION
As transactions aren't supported by twemproxy, this patch removes multi() and makes express-rate compliant with twemproxy.
