### PR TITLE
Updated the status code for over limit based on RFC 6585

### DIFF
--- a/lib/rate.js
+++ b/lib/rate.js
@@ -3,7 +3,7 @@ exports.Base             = require('./base');
 exports.Memory           = require('./memory');
 exports.Redis            = require('./redis');
 
-// 
+//
 // DEFAULTS FOR OPTIONS
 // extensibility point
 //
@@ -39,7 +39,7 @@ exports.defaults = function () {
             // we zero it here so it doesnt confuse the user
 
             // logic behind this is so for REDIS, we only have to make one increment request (which returns
-            // the current count), with 
+            // the current count), with
             // one roundtrip to the server. Otherwise, we would have to first check what the value is and
             // then increment if smaller (which is two roundtrips to the server)
             // if someone knows how to do conditionals in REDIS multi transactions, let me know!
@@ -56,9 +56,9 @@ exports.defaults = function () {
         },
 
         onLimitReached: function (req, res, rate, limit, resetTime, next) {
-            
-            // HTTP code 420 from http://mehack.com/inventing-a-http-response-code-aka-seriously
-            res.json({error: 'Rate limit exceeded. Check headers for limit information.'}, {status: 420});
+
+            // HTTP code 429 based on RFC 6585
+            res.status(429).json({error: 'Rate limit exceeded. Check headers for limit information.'});
         }
 
     };
@@ -102,7 +102,7 @@ exports.middleware = function recordRate(options) {
                 } else {
 
                     next();
-                    
+
                 }
             };
         }


### PR DESCRIPTION
420 is not commonly used for over rate limit. Suggest follow RFC 6585 and use 429 - Too Many Requests. Also, the original one did not set status code but enveloped it. Changed it to status code.
